### PR TITLE
Refactor to use singledispatch

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -12,7 +12,6 @@ jobs:
   pytest:
 
     runs-on: ${{ matrix.os }}
-    if: "github.repository == 'skops-dev/skops'"
     strategy:
       fail-fast: false  # need to see which ones fail
       matrix:

--- a/skops/io/_general.py
+++ b/skops/io/_general.py
@@ -116,21 +116,3 @@ def function_get_state(obj, dst):
 def function_get_instance(obj, src):
     loaded = _import_obj(obj["__module__"], obj["__content__"])
     return loaded
-
-
-def get_state_methods():
-    return {
-        FunctionType: function_get_state,
-        dict: dict_get_state,
-        list: list_get_state,
-        tuple: tuple_get_state,
-    }
-
-
-def get_instance_methods():
-    return {
-        FunctionType: function_get_instance,
-        dict: dict_get_instance,
-        list: list_get_instance,
-        tuple: tuple_get_instance,
-    }

--- a/skops/io/_general.py
+++ b/skops/io/_general.py
@@ -5,12 +5,11 @@ from types import FunctionType
 
 import numpy as np
 
-from ._utils import _import_obj, gettype
+from ._utils import _import_obj, get_instance, get_state, gettype
 
 
+@get_state.register(dict)
 def dict_get_state(obj, dst):
-    from ._persist import get_state_method
-
     res = {
         "__class__": obj.__class__.__name__,
         "__module__": inspect.getmodule(type(obj)).__name__,
@@ -21,30 +20,28 @@ def dict_get_state(obj, dst):
             # convert numpy value to python object
             key = key.item()
         try:
-            content[key] = get_state_method(value)(value, dst)
+            content[key] = get_state(value, dst)
         except TypeError:
             content[key] = json.dumps(value)
     res["content"] = content
     return res
 
 
+@get_instance.register(dict)
 def dict_get_instance(state, src):
-    from ._persist import get_instance_method
-
     state.pop("__class__")
     state.pop("__module__")
     content = {}
     for key, value in state["content"].items():
         if isinstance(value, dict):
-            content[key] = get_instance_method(value)(value, src)
+            content[key] = get_instance(value, src)
         else:
             content[key] = json.loads(value)
     return content
 
 
+@get_state.register(list)
 def list_get_state(obj, dst):
-    from ._persist import get_state_method
-
     res = {
         "__class__": obj.__class__.__name__,
         "__module__": inspect.getmodule(type(obj)).__name__,
@@ -52,30 +49,28 @@ def list_get_state(obj, dst):
     content = []
     for value in obj:
         try:
-            content.append(get_state_method(value)(value, dst))
+            content.append(get_state(value, dst))
         except TypeError:
             content.append(json.dumps(value))
     res["content"] = content
     return res
 
 
+@get_instance.register(list)
 def list_get_instance(state, src):
-    from ._persist import get_instance_method
-
     state.pop("__class__")
     state.pop("__module__")
     content = []
     for value in state["content"]:
         if gettype(value):
-            content.append(get_instance_method(value)(value, src))
+            content.append(get_instance(value, src))
         else:
             content.append(json.loads(value))
     return content
 
 
+@get_state.register(tuple)
 def tuple_get_state(obj, dst):
-    from ._persist import get_state_method
-
     res = {
         "__class__": obj.__class__.__name__,
         "__module__": inspect.getmodule(type(obj)).__name__,
@@ -83,27 +78,28 @@ def tuple_get_state(obj, dst):
     content = ()
     for value in obj:
         try:
-            content += (get_state_method(value)(value, dst),)
+            content += (get_state(value, dst),)
         except TypeError:
             content += (json.dumps(value),)
     res["content"] = content
     return res
 
 
+@get_instance.register(tuple)
 def tuple_get_instance(state, src):
-    from ._persist import get_instance_method
-
     state.pop("__class__")
     state.pop("__module__")
     content = ()
     for value in state["content"]:
         if gettype(value):
-            content += (get_instance_method(value)(value, src),)
+            content += (get_instance(value, src),)
         else:
             content += (json.loads(value),)
     return content
 
 
+@get_state.register(np.ufunc)
+@get_state.register(FunctionType)
 def function_get_state(obj, dst):
     if isinstance(obj, partial):
         raise TypeError("partial function are not supported yet")
@@ -115,6 +111,8 @@ def function_get_state(obj, dst):
     return res
 
 
+@get_instance.register(np.ufunc)
+@get_instance.register(FunctionType)
 def function_get_instance(obj, src):
     loaded = _import_obj(obj["__module__"], obj["__content__"])
     return loaded

--- a/skops/io/_numpy.py
+++ b/skops/io/_numpy.py
@@ -6,9 +6,11 @@ from uuid import uuid4
 
 import numpy as np
 
-from ._utils import _import_obj
+from ._utils import _import_obj, get_instance, get_state
 
 
+@get_state.register(np.generic)
+@get_state.register(np.ndarray)
 def ndarray_get_state(obj, dst):
     res = {
         "__class__": obj.__class__.__name__,
@@ -33,6 +35,8 @@ def ndarray_get_state(obj, dst):
     return res
 
 
+@get_instance.register(np.generic)
+@get_instance.register(np.ndarray)
 def ndarray_get_instance(state, src):
     if state["type"] == "numpy":
         val = np.load(io.BytesIO(src.read(state["file"])), allow_pickle=False)
@@ -44,23 +48,3 @@ def ndarray_get_instance(state, src):
     else:
         val = np.array(json.loads(src.read(state["file"])))
     return val
-
-
-def get_state_methods():
-    from ._general import function_get_state
-
-    return {
-        np.ufunc: function_get_state,
-        np.ndarray: ndarray_get_state,
-        np.generic: ndarray_get_state,
-    }
-
-
-def get_instance_methods():
-    from ._general import function_get_instance
-
-    return {
-        np.ufunc: function_get_instance,
-        np.ndarray: ndarray_get_instance,
-        np.generic: ndarray_get_instance,
-    }

--- a/skops/io/_persist.py
+++ b/skops/io/_persist.py
@@ -1,50 +1,25 @@
 from __future__ import annotations
 
+import importlib
 import json
 import shutil
 import tempfile
 from pathlib import Path
 from zipfile import ZipFile
 
-from ._utils import _import_obj, gettype
+from ._utils import get_instance, get_state
 
 # We load these dictionaries from corresponding modules and merge them.
 modules = ["._general", "._numpy", "._sklearn"]
-GET_STATE_METHODS = {}
-GET_INSTANCE_METHODS = {}
 for module in modules:
-    GET_STATE_METHODS.update(
-        _import_obj(module, "get_state_methods", package="skops.io")()
-    )
-    GET_INSTANCE_METHODS.update(
-        _import_obj(module, "get_instance_methods", package="skops.io")()
-    )
-
-
-def get_state_method(obj):
-    # we go through the MRO and find the first class for which we have a method
-    # to save the object. For instance, we might have a function for
-    # BaseEstimator used for most classes, but a specialized one for Pipeline.
-    for cls in type(obj).mro():
-        if cls in GET_STATE_METHODS:
-            return GET_STATE_METHODS[cls]
-
-    raise TypeError(f"Can't serialize {type(obj)}")
-
-
-def get_instance_method(state):
-    cls_ = gettype(state)
-    for cls in cls_.mro():
-        if cls in GET_INSTANCE_METHODS:
-            return GET_INSTANCE_METHODS[cls]
-
-    raise TypeError(f"Can't deserialize {type(state)}")
+    # make sure the modules are initialized
+    importlib.import_module(module, package="skops.io")
 
 
 def save(obj, file):
     with tempfile.TemporaryDirectory() as dst:
         with open(Path(dst) / "schema.json", "w") as f:
-            json.dump(get_state_method(obj)(obj, dst), f, indent=2)
+            json.dump(get_state(obj, dst), f, indent=2)
 
         # we use the zip format since tarfile can be exploited to create files
         # outside of the destination directory:
@@ -56,4 +31,4 @@ def save(obj, file):
 def load(file):
     input_zip = ZipFile(file)
     schema = input_zip.read("schema.json")
-    return get_instance_method(json.loads(schema))(json.loads(schema), input_zip)
+    return get_instance(json.loads(schema), input_zip)

--- a/skops/io/_utils.py
+++ b/skops/io/_utils.py
@@ -1,4 +1,135 @@
 import importlib
+from functools import (  # type: ignore
+    GenericAlias,
+    _find_impl,
+    get_cache_token,
+    update_wrapper,
+)
+
+
+# This is an almost 1:1 copy of functools.singledispatch. There is one crucial
+# difference, however. Usually, we want to dispatch on the class of the object.
+# However, when we call get_instance, the object is *always* a dict, which
+# invalidates the dispatch. Therefore, we change the dispatcher to dispatch on
+# the instance, not the class. By default, we just use the class of the instance
+# being passed, i.e. we do exactly the same as in the original implementation.
+# However, if we encounter a state dict, we resolve the actual class from the
+# state dict first and then dispatch on that class. The changed lines are marked
+# as "# CHANGED".
+# fmt: off
+def singledispatch(func):
+    """Single-dispatch generic function decorator.
+
+    Transforms a function into a generic function, which can have different
+    behaviours depending upon the type of its first argument. The decorated
+    function acts as the default implementation, and additional
+    implementations can be registered using the register() attribute of the
+    generic function.
+    """
+    # There are many programs that use functools without singledispatch, so we
+    # trade-off making singledispatch marginally slower for the benefit of
+    # making start-up of such applications slightly faster.
+    import types
+    import weakref
+
+    registry = {}
+    dispatch_cache = weakref.WeakKeyDictionary()
+    cache_token = None
+
+    def dispatch(instance):  # CHANGED: variable name cls->instance
+        """generic_func.dispatch(cls) -> <function implementation>
+
+        Runs the dispatch algorithm to return the best available implementation
+        for the given *cls* registered on *generic_func*.
+
+        """
+        # CHANGED: check if we deal with a state dict, in which case we use it
+        # to resolve the correct class. Otherwise, just use the class of the
+        # instance.
+        if (
+            isinstance(instance, dict)
+            and "__module__" in instance
+            and "__class__" in instance
+        ):
+            cls = gettype(instance)
+        else:
+            cls = instance.__class__
+
+        nonlocal cache_token
+        if cache_token is not None:
+            current_token = get_cache_token()
+            if cache_token != current_token:
+                dispatch_cache.clear()
+                cache_token = current_token
+        try:
+            impl = dispatch_cache[cls]
+        except KeyError:
+            try:
+                impl = registry[cls]
+            except KeyError:
+                impl = _find_impl(cls, registry)
+            dispatch_cache[cls] = impl
+        return impl
+
+    def _is_valid_dispatch_type(cls):
+        return isinstance(cls, type) and not isinstance(cls, GenericAlias)
+
+    def register(cls, func=None):
+        """generic_func.register(cls, func) -> func
+
+        Registers a new implementation for the given *cls* on a *generic_func*.
+
+        """
+        nonlocal cache_token
+        if _is_valid_dispatch_type(cls):
+            if func is None:
+                return lambda f: register(cls, f)
+        else:
+            if func is not None:
+                raise TypeError(
+                    f"Invalid first argument to `register()`. "
+                    f"{cls!r} is not a class."
+                )
+            ann = getattr(cls, '__annotations__', {})
+            if not ann:
+                raise TypeError(
+                    f"Invalid first argument to `register()`: {cls!r}. "
+                    f"Use either `@register(some_class)` or plain `@register` "
+                    f"on an annotated function."
+                )
+            func = cls
+            # only import typing if annotation parsing is necessary
+            from typing import get_type_hints
+            argname, cls = next(iter(get_type_hints(func).items()))
+            if not _is_valid_dispatch_type(cls):
+                raise TypeError(
+                    f"Invalid annotation for {argname!r}. "
+                    f"{cls!r} is not a class."
+                )
+
+        registry[cls] = func
+        if cache_token is None and hasattr(cls, '__abstractmethods__'):
+            cache_token = get_cache_token()
+        dispatch_cache.clear()
+        return func
+
+    def wrapper(*args, **kw):
+        if not args:
+            raise TypeError(f'{funcname} requires at least '
+                            '1 positional argument')
+
+        # CHANGED: dispatch on instance, not class
+        return dispatch(args[0])(*args, **kw)
+
+    funcname = getattr(func, '__name__', 'singledispatch function')
+    registry[object] = func
+    wrapper.register = register
+    wrapper.dispatch = dispatch
+    wrapper.registry = types.MappingProxyType(registry)
+    wrapper._clear_cache = dispatch_cache.clear
+    update_wrapper(wrapper, func)
+    return wrapper
+# fmt: on
 
 
 def _import_obj(module, cls_or_func, package=None):
@@ -9,3 +140,13 @@ def gettype(state):
     if "__module__" in state and "__class__" in state:
         return _import_obj(state["__module__"], state["__class__"])
     return None
+
+
+@singledispatch
+def get_state(obj, dst):
+    raise TypeError(f"Getting the state of type {type(obj)} is not supported yet")
+
+
+@singledispatch
+def get_instance(obj):
+    raise TypeError(f"Creating an instance of type {type(obj)} is not supported yet")

--- a/skops/io/_utils.py
+++ b/skops/io/_utils.py
@@ -1,10 +1,7 @@
 import importlib
-from functools import (  # type: ignore
-    GenericAlias,
-    _find_impl,
-    get_cache_token,
-    update_wrapper,
-)
+from functools import _find_impl, get_cache_token, update_wrapper  # type: ignore
+
+from skops.utils.fixes import GenericAlias
 
 
 # This is an almost 1:1 copy of functools.singledispatch. There is one crucial

--- a/skops/utils/fixes.py
+++ b/skops/utils/fixes.py
@@ -4,6 +4,7 @@
 import sys
 from contextlib import suppress
 from pathlib import Path
+from typing import List
 
 if sys.version_info >= (3, 8):
     # py>=3.8
@@ -20,6 +21,11 @@ else:
     # if you're removing this, you should also remove the dependency from
     # _min_dependencies.py
     from typing_extensions import Literal  # noqa
+
+if sys.version_info >= (3, 9):
+    from types import GenericAlias
+else:
+    GenericAlias = type(List[int])
 
 
 def path_unlink(path: Path, missing_ok: bool = False) -> None:


### PR DESCRIPTION
This is a proposal to refactor the code to use `singledispatch`.

## Description

So far, we have written a custom dispatch logic by walking the mro until we find a suitable object. Now we use a `singledispatch` decorator instead which under the hood does something very similar but is based on the builtin `singledispatch` decorator.

### Pros

It is no longer necessary to litter the code with `get_state_method` and `get_instance_method` calls, as that is resolved through the decorator. Also, we can assume that the `singledispatch` decorator is battle tested and thus more robust than our custom implementation. Moreover, it seems to be using some form of caching, so maybe it's also faster. Finally, since we no longer need to resolve the methods, the local imports are gone.

### Cons

Unfortunately, we could not rely completely on the built in `singledispatch` decorator. The reason is the following:

Usually, we want to dispatch on the class of the object. However, when we call get_instance, the object is *always* a dict, which invalidates the dispatch. Therefore, we change the dispatcher to dispatch on the instance, not the class. By default, we just use the class of the instance being passed, i.e. we do exactly the same as in the original implementation. However, if we encounter a state dict, we resolve the actual class from the state dict first and then dispatch on that class.

Another con is that we have to decorate all the functions that we plan on using. Probably, this could be solved similarly to the previous implementation by dynamically importing the functions and decorating them on the fly, I have not tried.