### PR TITLE
Dynamically register dispatch functions

### DIFF
--- a/skops/io/_general.py
+++ b/skops/io/_general.py
@@ -108,7 +108,6 @@ def function_get_instance(obj, src):
     return loaded
 
 
-@get_state.register(type)
 def type_get_state(obj, dst):
     # To serialize a type, we first need to set the metadata to tell that it's
     # a type, then store the type's info itself in the content field.
@@ -123,21 +122,24 @@ def type_get_state(obj, dst):
     return res
 
 
-@get_instance.register(type)
 def type_get_instance(obj, src):
     loaded = _import_obj(obj["content"]["__module__"], obj["content"]["__class__"])
     return loaded
 
 
+# tuples of type and function that gets the state of that type
 GET_STATE_DISPATCH_FUNCTIONS = [
     (dict, dict_get_state),
     (list, list_get_state),
     (tuple, tuple_get_state),
     (FunctionType, function_get_state),
+    (type, type_get_state),
 ]
+# tuples of type and function that creates the instance of that type
 GET_INSTANCE_DISPATCH_FUNCTIONS = [
     (dict, dict_get_instance),
     (list, list_get_instance),
     (tuple, tuple_get_instance),
     (FunctionType, function_get_instance),
+    (type, type_get_instance),
 ]

--- a/skops/io/_general.py
+++ b/skops/io/_general.py
@@ -8,7 +8,6 @@ import numpy as np
 from ._utils import _import_obj, get_instance, get_state, gettype
 
 
-@get_state.register(dict)
 def dict_get_state(obj, dst):
     res = {
         "__class__": obj.__class__.__name__,
@@ -27,7 +26,6 @@ def dict_get_state(obj, dst):
     return res
 
 
-@get_instance.register(dict)
 def dict_get_instance(state, src):
     state.pop("__class__")
     state.pop("__module__")
@@ -40,7 +38,6 @@ def dict_get_instance(state, src):
     return content
 
 
-@get_state.register(list)
 def list_get_state(obj, dst):
     res = {
         "__class__": obj.__class__.__name__,
@@ -56,7 +53,6 @@ def list_get_state(obj, dst):
     return res
 
 
-@get_instance.register(list)
 def list_get_instance(state, src):
     state.pop("__class__")
     state.pop("__module__")
@@ -69,7 +65,6 @@ def list_get_instance(state, src):
     return content
 
 
-@get_state.register(tuple)
 def tuple_get_state(obj, dst):
     res = {
         "__class__": obj.__class__.__name__,
@@ -85,7 +80,6 @@ def tuple_get_state(obj, dst):
     return res
 
 
-@get_instance.register(tuple)
 def tuple_get_instance(state, src):
     state.pop("__class__")
     state.pop("__module__")
@@ -98,7 +92,6 @@ def tuple_get_instance(state, src):
     return content
 
 
-@get_state.register(FunctionType)
 def function_get_state(obj, dst):
     if isinstance(obj, partial):
         raise TypeError("partial function are not supported yet")
@@ -110,8 +103,6 @@ def function_get_state(obj, dst):
     return res
 
 
-@get_instance.register(np.ufunc)
-@get_instance.register(FunctionType)
 def function_get_instance(obj, src):
     loaded = _import_obj(obj["__module__"], obj["content"])
     return loaded
@@ -136,3 +127,17 @@ def type_get_state(obj, dst):
 def type_get_instance(obj, src):
     loaded = _import_obj(obj["content"]["__module__"], obj["content"]["__class__"])
     return loaded
+
+
+GET_STATE_DISPATCH_FUNCTIONS = [
+    (dict, dict_get_state),
+    (list, list_get_state),
+    (tuple, tuple_get_state),
+    (FunctionType, function_get_state),
+]
+GET_INSTANCE_DISPATCH_FUNCTIONS = [
+    (dict, dict_get_instance),
+    (list, list_get_instance),
+    (tuple, tuple_get_instance),
+    (FunctionType, function_get_instance),
+]

--- a/skops/io/_numpy.py
+++ b/skops/io/_numpy.py
@@ -62,12 +62,13 @@ def ufunc_get_state(obj, dst):
     return res
 
 
+# tuples of type and function that gets the state of that type
 GET_STATE_DISPATCH_FUNCTIONS = [
     (np.generic, ndarray_get_state),
     (np.ndarray, ndarray_get_state),
     (np.ufunc, ufunc_get_state),
 ]
-
+# tuples of type and function that creates the instance of that type
 GET_INSTANCE_DISPATCH_FUNCTIONS = [
     (np.generic, ndarray_get_instance),
     (np.ndarray, ndarray_get_instance),

--- a/skops/io/_numpy.py
+++ b/skops/io/_numpy.py
@@ -7,11 +7,10 @@ from uuid import uuid4
 
 import numpy as np
 
-from ._utils import _import_obj, get_instance, get_state
+from ._general import function_get_instance
+from ._utils import _import_obj
 
 
-@get_state.register(np.generic)
-@get_state.register(np.ndarray)
 def ndarray_get_state(obj, dst):
     res = {
         "__class__": obj.__class__.__name__,
@@ -36,8 +35,6 @@ def ndarray_get_state(obj, dst):
     return res
 
 
-@get_instance.register(np.generic)
-@get_instance.register(np.ndarray)
 def ndarray_get_instance(state, src):
     if state["type"] == "numpy":
         val = np.load(io.BytesIO(src.read(state["file"])), allow_pickle=False)
@@ -54,7 +51,6 @@ def ndarray_get_instance(state, src):
 # For numpy.ufunc we need to get the type from the type's module, but for other
 # functions we get it from objet's module directly. Therefore sett a especial
 # get_state method for them here. The load is the same as other functions.
-@get_state.register(np.ufunc)
 def ufunc_get_state(obj, dst):
     if isinstance(obj, partial):
         raise TypeError("partial function are not supported yet")
@@ -64,3 +60,16 @@ def ufunc_get_state(obj, dst):
         "content": obj.__name__,
     }
     return res
+
+
+GET_STATE_DISPATCH_FUNCTIONS = [
+    (np.generic, ndarray_get_state),
+    (np.ndarray, ndarray_get_state),
+    (np.ufunc, ufunc_get_state),
+]
+
+GET_INSTANCE_DISPATCH_FUNCTIONS = [
+    (np.generic, ndarray_get_instance),
+    (np.ndarray, ndarray_get_instance),
+    (np.ufunc, function_get_instance),
+]

--- a/skops/io/_persist.py
+++ b/skops/io/_persist.py
@@ -9,11 +9,16 @@ from zipfile import ZipFile
 
 from ._utils import get_instance, get_state
 
-# We load these dictionaries from corresponding modules and merge them.
+# We load the dispatch functions from the corresponding modules and register
+# them.
 modules = ["._general", "._numpy", "._sklearn"]
-for module in modules:
-    # make sure the modules are initialized
-    importlib.import_module(module, package="skops.io")
+for module_name in modules:
+    # register exposed functions for get_state and get_instance
+    module = importlib.import_module(module_name, package="skops.io")
+    for cls, method in getattr(module, "GET_STATE_DISPATCH_FUNCTIONS", []):
+        get_state.register(cls)(method)
+    for cls, method in getattr(module, "GET_INSTANCE_DISPATCH_FUNCTIONS", []):
+        get_instance.register(cls)(method)
 
 
 def save(obj, file):

--- a/skops/io/_sklearn.py
+++ b/skops/io/_sklearn.py
@@ -100,11 +100,13 @@ def BaseEstimator_get_instance(state, src):
     return instance
 
 
+# tuples of type and function that gets the state of that type
 GET_STATE_DISPATCH_FUNCTIONS = [
     (Tree, BaseEstimator_get_state),
     (_CalibratedClassifier, BaseEstimator_get_state),
     (BaseEstimator, BaseEstimator_get_state),
 ]
+# tuples of type and function that creates the instance of that type
 GET_INSTANCE_DISPATCH_FUNCTIONS = [
     (Tree, BaseEstimator_get_instance),
     (_CalibratedClassifier, BaseEstimator_get_instance),

--- a/skops/io/_sklearn.py
+++ b/skops/io/_sklearn.py
@@ -8,9 +8,6 @@ from sklearn.tree._tree import Tree
 from ._utils import get_instance, get_state, gettype
 
 
-@get_state.register(Tree)
-@get_state.register(_CalibratedClassifier)
-@get_state.register(BaseEstimator)
 def BaseEstimator_get_state(obj, dst):
     res = {
         "__class__": obj.__class__.__name__,
@@ -67,9 +64,6 @@ def BaseEstimator_get_state(obj, dst):
     return res
 
 
-@get_instance.register(Tree)
-@get_instance.register(_CalibratedClassifier)
-@get_instance.register(BaseEstimator)
 def BaseEstimator_get_instance(state, src):
     cls = gettype(state)
     state.pop("__class__")
@@ -104,3 +98,15 @@ def BaseEstimator_get_instance(state, src):
         instance.__dict__.update(attrs)
 
     return instance
+
+
+GET_STATE_DISPATCH_FUNCTIONS = [
+    (Tree, BaseEstimator_get_state),
+    (_CalibratedClassifier, BaseEstimator_get_state),
+    (BaseEstimator, BaseEstimator_get_state),
+]
+GET_INSTANCE_DISPATCH_FUNCTIONS = [
+    (Tree, BaseEstimator_get_instance),
+    (_CalibratedClassifier, BaseEstimator_get_instance),
+    (BaseEstimator, BaseEstimator_get_instance),
+]


### PR DESCRIPTION
Instead of using the `singledispatch` decorator, the modules are now responsible to expose the functions to dispatch and their types. Then we can dynamically collect and register them. This is more similar to the initial code and helps us in being more dynamic.

I decided to go with list of tuples stored on constants `GET_STATE_DISPATCH_FUNCTIONS` and `GET_INSTANCE_DISPATCH_FUNCTIONS` to expose the functions to register. @adrinjalali LMK if you prefer a dict or function/generator instead, I don't have a strong reference.