### PR TITLE
A couple of fixes to make more tests pass

### DIFF
--- a/skops/io/_general.py
+++ b/skops/io/_general.py
@@ -4,19 +4,13 @@ from types import FunctionType
 
 import numpy as np
 
-from ._utils import (
-    _import_obj,
-    get_instance,
-    get_state,
-    try_get_instance,
-    try_get_state,
-)
+from ._utils import _import_obj, get_module, try_get_instance, try_get_state
 
 
 def dict_get_state(obj, dst):
     res = {
         "__class__": obj.__class__.__name__,
-        "__module__": inspect.getmodule(type(obj)).__name__,
+        "__module__": get_module(obj),
     }
     content = {}
     for key, value in obj.items():
@@ -40,7 +34,7 @@ def dict_get_instance(state, src):
 def list_get_state(obj, dst):
     res = {
         "__class__": obj.__class__.__name__,
-        "__module__": inspect.getmodule(type(obj)).__name__,
+        "__module__": get_module(obj),
     }
     content = []
     for value in obj:
@@ -61,7 +55,7 @@ def list_get_instance(state, src):
 def tuple_get_state(obj, dst):
     res = {
         "__class__": obj.__class__.__name__,
-        "__module__": inspect.getmodule(type(obj)).__name__,
+        "__module__": get_module(obj),
     }
     content = ()
     for value in obj:
@@ -100,7 +94,7 @@ def type_get_state(obj, dst):
     # a type, then store the type's info itself in the content field.
     res = {
         "__class__": obj.__class__.__name__,
-        "__module__": inspect.getmodule(type(obj)).__name__,
+        "__module__": get_module(obj),
         "content": {
             "__class__": obj.__name__,
             "__module__": inspect.getmodule(obj).__name__,

--- a/skops/io/_general.py
+++ b/skops/io/_general.py
@@ -10,7 +10,7 @@ from ._utils import _import_obj, get_module, try_get_instance, try_get_state
 def dict_get_state(obj, dst):
     res = {
         "__class__": obj.__class__.__name__,
-        "__module__": get_module(obj),
+        "__module__": get_module(type(obj)),
     }
     content = {}
     for key, value in obj.items():
@@ -34,7 +34,7 @@ def dict_get_instance(state, src):
 def list_get_state(obj, dst):
     res = {
         "__class__": obj.__class__.__name__,
-        "__module__": get_module(obj),
+        "__module__": get_module(type(obj)),
     }
     content = []
     for value in obj:
@@ -55,7 +55,7 @@ def list_get_instance(state, src):
 def tuple_get_state(obj, dst):
     res = {
         "__class__": obj.__class__.__name__,
-        "__module__": get_module(obj),
+        "__module__": get_module(type(obj)),
     }
     content = ()
     for value in obj:
@@ -94,10 +94,10 @@ def type_get_state(obj, dst):
     # a type, then store the type's info itself in the content field.
     res = {
         "__class__": obj.__class__.__name__,
-        "__module__": get_module(obj),
+        "__module__": get_module(type(obj)),
         "content": {
             "__class__": obj.__name__,
-            "__module__": inspect.getmodule(obj).__name__,
+            "__module__": get_module(obj),
         },
     }
     return res

--- a/skops/io/_numpy.py
+++ b/skops/io/_numpy.py
@@ -1,4 +1,3 @@
-import inspect
 import io
 import json
 from functools import partial
@@ -8,13 +7,13 @@ from uuid import uuid4
 import numpy as np
 
 from ._general import function_get_instance
-from ._utils import _import_obj
+from ._utils import _import_obj, get_module
 
 
 def ndarray_get_state(obj, dst):
     res = {
         "__class__": obj.__class__.__name__,
-        "__module__": inspect.getmodule(type(obj)).__name__,
+        "__module__": get_module(obj),
     }
 
     try:
@@ -56,7 +55,7 @@ def ufunc_get_state(obj, dst):
         raise TypeError("partial function are not supported yet")
     res = {
         "__class__": obj.__class__.__name__,
-        "__module__": inspect.getmodule(type(obj)).__name__,
+        "__module__": get_module(obj),
         "content": obj.__name__,
     }
     return res

--- a/skops/io/_numpy.py
+++ b/skops/io/_numpy.py
@@ -13,7 +13,7 @@ from ._utils import _import_obj, get_module
 def ndarray_get_state(obj, dst):
     res = {
         "__class__": obj.__class__.__name__,
-        "__module__": get_module(obj),
+        "__module__": get_module(type(obj)),
     }
 
     try:

--- a/skops/io/_persist.py
+++ b/skops/io/_persist.py
@@ -11,7 +11,7 @@ from ._utils import get_instance, get_state
 
 # We load the dispatch functions from the corresponding modules and register
 # them.
-modules = ["._general", "._numpy", "._sklearn"]
+modules = ["._general", "._numpy", "._scipy", "._sklearn"]
 for module_name in modules:
     # register exposed functions for get_state and get_instance
     module = importlib.import_module(module_name, package="skops.io")

--- a/skops/io/_scipy.py
+++ b/skops/io/_scipy.py
@@ -8,7 +8,7 @@ from ._utils import get_module
 def sparse_matrix_get_state(obj, dst):
     res = {
         "__class__": obj.__class__.__name__,
-        "__module__": get_module(obj),
+        "__module__": get_module(type(obj)),
     }
 
     f_name = f"{uuid4()}.npz"

--- a/skops/io/_scipy.py
+++ b/skops/io/_scipy.py
@@ -1,0 +1,44 @@
+import inspect
+from uuid import uuid4
+
+from scipy.sparse import load_npz, save_npz, spmatrix
+
+
+def sparse_matrix_get_state(obj, dst):
+    res = {
+        "__class__": obj.__class__.__name__,
+        "__module__": inspect.getmodule(type(obj)).__name__,
+    }
+
+    f_name = f"{uuid4()}.npz"
+    save_npz(f_name, obj)
+    res["type"] = "scipy"
+    res["file"] = f_name
+
+    return res
+
+
+def sparse_matrix_get_instance(state, src):
+    if state["type"] != "scipy":
+        raise TypeError(
+            f"Cannot load object of type {state['__module__']}.{state['__class__']}"
+        )
+
+    # scipy load_npz uses numpy.save with allow_pickle=False under the hood, so
+    # we're safe using it
+    val = load_npz(state["file"])
+    return val
+
+
+# tuples of type and function that gets the state of that type
+GET_STATE_DISPATCH_FUNCTIONS = [
+    # use 'spmatrix' to check if a matrix is a sparse matrix because that is
+    # what scipy.sparse.issparse checks
+    (spmatrix, sparse_matrix_get_state),
+]
+# tuples of type and function that creates the instance of that type
+GET_INSTANCE_DISPATCH_FUNCTIONS = [
+    # use 'spmatrix' to check if a matrix is a sparse matrix because that is
+    # what scipy.sparse.issparse checks
+    (spmatrix, sparse_matrix_get_instance),
+]

--- a/skops/io/_scipy.py
+++ b/skops/io/_scipy.py
@@ -1,13 +1,14 @@
-import inspect
 from uuid import uuid4
 
 from scipy.sparse import load_npz, save_npz, spmatrix
+
+from ._utils import get_module
 
 
 def sparse_matrix_get_state(obj, dst):
     res = {
         "__class__": obj.__class__.__name__,
-        "__module__": inspect.getmodule(type(obj)).__name__,
+        "__module__": get_module(obj),
     }
 
     f_name = f"{uuid4()}.npz"

--- a/skops/io/_sklearn.py
+++ b/skops/io/_sklearn.py
@@ -6,7 +6,7 @@ from sklearn.calibration import _CalibratedClassifier
 from sklearn.tree._tree import Tree
 from sklearn.utils import Bunch
 
-from ._general import dict_get_instance, dict_get_state
+from ._general import dict_get_instance
 from ._utils import get_instance, get_module, get_state, gettype, try_get_state
 
 
@@ -108,7 +108,6 @@ def bunch_get_instance(state, src):
 # tuples of type and function that gets the state of that type
 GET_STATE_DISPATCH_FUNCTIONS = [
     (Tree, BaseEstimator_get_state),
-    (Bunch, dict_get_state),
     (_CalibratedClassifier, BaseEstimator_get_state),
     (BaseEstimator, BaseEstimator_get_state),
 ]

--- a/skops/io/_sklearn.py
+++ b/skops/io/_sklearn.py
@@ -19,7 +19,7 @@ def BaseEstimator_get_state(obj, dst):
     if hasattr(obj, "__getstate__"):
         attrs = obj.__getstate__()
     else:
-        attrs = obj.__dir__
+        attrs = obj.__dict__
 
     reduce = False
     if hasattr(obj, "__reduce__"):

--- a/skops/io/_sklearn.py
+++ b/skops/io/_sklearn.py
@@ -7,13 +7,13 @@ from sklearn.tree._tree import Tree
 from sklearn.utils import Bunch
 
 from ._general import dict_get_instance, dict_get_state
-from ._utils import get_instance, get_state, gettype, try_get_state
+from ._utils import get_instance, get_module, get_state, gettype, try_get_state
 
 
 def BaseEstimator_get_state(obj, dst):
     res = {
         "__class__": obj.__class__.__name__,
-        "__module__": inspect.getmodule(type(obj)).__name__,
+        "__module__": get_module(obj),
     }
 
     if hasattr(obj, "__getstate__"):

--- a/skops/io/_sklearn.py
+++ b/skops/io/_sklearn.py
@@ -13,7 +13,7 @@ from ._utils import get_instance, get_module, get_state, gettype, try_get_state
 def BaseEstimator_get_state(obj, dst):
     res = {
         "__class__": obj.__class__.__name__,
-        "__module__": get_module(obj),
+        "__module__": get_module(type(obj)),
     }
 
     if hasattr(obj, "__getstate__"):

--- a/skops/io/_sklearn.py
+++ b/skops/io/_sklearn.py
@@ -4,7 +4,9 @@ import json
 from sklearn.base import BaseEstimator
 from sklearn.calibration import _CalibratedClassifier
 from sklearn.tree._tree import Tree
+from sklearn.utils import Bunch
 
+from ._general import dict_get_instance, dict_get_state
 from ._utils import get_instance, get_state, gettype, try_get_state
 
 
@@ -97,15 +99,23 @@ def BaseEstimator_get_instance(state, src):
     return instance
 
 
+def bunch_get_instance(state, src):
+    # Bunch is just a wrapper for dict
+    content = dict_get_instance(state, src)
+    return Bunch(**content)
+
+
 # tuples of type and function that gets the state of that type
 GET_STATE_DISPATCH_FUNCTIONS = [
     (Tree, BaseEstimator_get_state),
+    (Bunch, dict_get_state),
     (_CalibratedClassifier, BaseEstimator_get_state),
     (BaseEstimator, BaseEstimator_get_state),
 ]
 # tuples of type and function that creates the instance of that type
 GET_INSTANCE_DISPATCH_FUNCTIONS = [
     (Tree, BaseEstimator_get_instance),
+    (Bunch, bunch_get_instance),
     (_CalibratedClassifier, BaseEstimator_get_instance),
     (BaseEstimator, BaseEstimator_get_instance),
 ]

--- a/skops/io/_utils.py
+++ b/skops/io/_utils.py
@@ -165,7 +165,7 @@ def get_module(obj):
         If the module for that object cannot be found.
 
     """
-    module = inspect.getmodule(type(obj))
+    module = inspect.getmodule(obj)
     if module is None:
         raise ModuleNotFoundError(f"No module found for type {type(obj)}")
 

--- a/skops/io/_utils.py
+++ b/skops/io/_utils.py
@@ -1,4 +1,5 @@
 import importlib
+import inspect
 import json  # type: ignore
 from functools import _find_impl, get_cache_token, update_wrapper  # type: ignore
 from types import FunctionType
@@ -143,6 +144,32 @@ def gettype(state):
             return FunctionType
         return _import_obj(state["__module__"], state["__class__"])
     return None
+
+
+def get_module(obj):
+    """Find module for given object
+
+    Parameters
+    ----------
+    obj: Any
+       Object whose module is requested.
+
+    Returns
+    -------
+    name: str
+        Name of the module.
+
+    Raises
+    ------
+    ModuleNotFoundError
+        If the module for that object cannot be found.
+
+    """
+    module = inspect.getmodule(type(obj))
+    if module is None:
+        raise ModuleNotFoundError(f"No module found for type {type(obj)}")
+
+    return module.__name__
 
 
 @singledispatch

--- a/skops/io/tests/test_persist.py
+++ b/skops/io/tests/test_persist.py
@@ -4,7 +4,8 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-from scipy import special
+from scipy import sparse, special
+from sklearn.base import BaseEstimator
 from sklearn.datasets import make_classification
 from sklearn.exceptions import SkipTestWarning
 from sklearn.linear_model import LogisticRegression
@@ -107,11 +108,41 @@ def _tested_estimators(type_filter=None):
     )
 
 
+def _is_steps_like(obj):
+    # helper function to check if an object is something like Pipeline.steps,
+    # i.e. a list of tuples of names and estimators
+    if not isinstance(obj, list):  # must be a list
+        return False
+
+    if not obj:  # must not be empty
+        return False
+
+    if not isinstance(obj[0], tuple):  # must be list of tuples
+        return False
+
+    lens = set(map(len, obj))
+    if not lens == {2}:  # all elements must be length 2 tuples
+        return False
+
+    keys, vals = list(zip(*obj))
+
+    if len(keys) != len(set(keys)):  # keys must be unique
+        return False
+
+    if not all(map(lambda x: isinstance(x, (type(None), BaseEstimator)), vals)):
+        # values must be BaseEstimators or None
+        return False
+
+    return True
+
+
 def _assert_vals_equal(val1, val2):
     if hasattr(val1, "__getstate__"):
         # This includes BaseEstimator since they implement __getstate__ and
         # that returns the parameters as well.
-        _assert_vals_equal(val1.__getstate__(), val2.__getstate__())
+        assert_params_equal(val1.__getstate__(), val2.__getstate__())
+    elif sparse.issparse(val1):
+        assert sparse.issparse(val2) and ((val1 - val2).nnz == 0)
     elif isinstance(val1, (np.ndarray, np.generic)):
         if len(val1.dtype) == 0:
             # simple comparison of arrays with simple dtypes, almost all arrays
@@ -143,13 +174,9 @@ def assert_params_equal(params1, params2):
         val1, val2 = params1[key], params2[key]
         assert type(val1) == type(val2)
 
-        if (
-            (key == "steps")
-            or (key == "transformer_list")
-            or key.endswith("__steps")
-            or key.endswith("__transformer_list")
-        ):
-            # we deal with a pipeline or feature union
+        if _is_steps_like(val1):
+            # Deal with Pipeline.steps, FeatureUnion.transformer_list, etc.
+            assert _is_steps_like(val2)
             val1, val2 = dict(val1), dict(val2)
 
         if isinstance(val1, (tuple, list)):

--- a/skops/io/tests/test_persist.py
+++ b/skops/io/tests/test_persist.py
@@ -155,6 +155,10 @@ def _assert_vals_equal(val1, val2):
         else:
             # we don't know what to do with these values, for now.
             assert False
+    elif isinstance(val1, (tuple, list)):
+        assert len(val1) == len(val2)
+        for subval1, subval2 in zip(val1, val2):
+            _assert_vals_equal(subval1, subval2)
     elif isinstance(val1, float) and np.isnan(val1):
         assert np.isnan(val2)
     elif isinstance(val1, dict):

--- a/skops/io/tests/test_persist.py
+++ b/skops/io/tests/test_persist.py
@@ -210,7 +210,7 @@ def _get_learned_attrs(estimator):
 @pytest.mark.parametrize(
     "estimator", _tested_estimators(), ids=_get_check_estimator_ids
 )
-def test_can_persist_non_fitted(estimator, request):
+def test_can_persist_non_fitted(estimator):
     """Check that non-fitted estimators can be persisted."""
     if estimator.__class__.__name__ in ESTIMATORS_TO_IGNORE:
         pytest.skip()
@@ -222,7 +222,7 @@ def test_can_persist_non_fitted(estimator, request):
 @pytest.mark.parametrize(
     "estimator", _tested_estimators(), ids=_get_check_estimator_ids
 )
-def test_can_persist_fitted(estimator, request):
+def test_can_persist_fitted(estimator):
     """Check that fitted estimators can be persisted and return the right results."""
     if estimator.__class__.__name__ in ESTIMATORS_TO_IGNORE:
         pytest.skip()


### PR DESCRIPTION
- Test function now checks if we have a `Pipeline.steps`-like attribute by looking at the values, not the attribute name, because some sklearn objects have this with different names.
- Support for `scipy.sparse` matrices
- Support for `sklearn.Bunch`

Locally, this brings the errors down from 62 to 49. Ready for review @adrinjalali 

**Edit**

- Added a `get_module` utility function.