### PR TITLE
Add support for BallTree, BinaryTree

### DIFF
--- a/skops/io/_sklearn.py
+++ b/skops/io/_sklearn.py
@@ -14,7 +14,28 @@ from sklearn.linear_model._sgd_fast import (
     SquaredLoss,
 )
 from sklearn.metrics import DistanceMetric
-from sklearn.metrics._dist_metrics import METRIC_MAPPING
+from sklearn.metrics._dist_metrics import (
+    BrayCurtisDistance,
+    CanberraDistance,
+    ChebyshevDistance,
+    DiceDistance,
+    EuclideanDistance,
+    HammingDistance,
+    HaversineDistance,
+    JaccardDistance,
+    KulsinskiDistance,
+    MahalanobisDistance,
+    ManhattanDistance,
+    MatchingDistance,
+    MinkowskiDistance,
+    PyFuncDistance,
+    RogersTanimotoDistance,
+    RussellRaoDistance,
+    SEuclideanDistance,
+    SokalMichenerDistance,
+    SokalSneathDistance,
+    WMinkowskiDistance,
+)
 from sklearn.neighbors import BallTree, KDTree
 from sklearn.tree._tree import Tree
 from sklearn.utils import Bunch
@@ -40,7 +61,33 @@ ALLOWED_SGD_LOSSES = {
     SquaredEpsilonInsensitive,
 }
 ALLOWED_BINARY_TREES = {BallTree, KDTree}
-ALLOWED_DIST_METRICS = set(METRIC_MAPPING.values())
+ALLOWED_DIST_METRICS = {
+    BrayCurtisDistance,
+    CanberraDistance,
+    ChebyshevDistance,
+    ChebyshevDistance,
+    DiceDistance,
+    EuclideanDistance,
+    EuclideanDistance,
+    HammingDistance,
+    HaversineDistance,
+    JaccardDistance,
+    KulsinskiDistance,
+    MahalanobisDistance,
+    ManhattanDistance,
+    ManhattanDistance,
+    ManhattanDistance,
+    MatchingDistance,
+    MinkowskiDistance,
+    MinkowskiDistance,
+    PyFuncDistance,
+    RogersTanimotoDistance,
+    RussellRaoDistance,
+    SEuclideanDistance,
+    SokalMichenerDistance,
+    SokalSneathDistance,
+    WMinkowskiDistance,
+}
 
 
 def generic_get_state(obj, dst):

--- a/skops/io/tests/test_persist.py
+++ b/skops/io/tests/test_persist.py
@@ -116,6 +116,11 @@ def _tested_estimators(type_filter=None):
         inverse_func=special.erfinv,
     )
 
+    from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
+
+    yield KNeighborsClassifier(algorithm="kd_tree")
+    yield KNeighborsRegressor(algorithm="ball_tree")
+
 
 def _is_steps_like(obj):
     # helper function to check if an object is something like Pipeline.steps,

--- a/skops/io/tests/test_persist.py
+++ b/skops/io/tests/test_persist.py
@@ -549,7 +549,10 @@ def test_metainfo():
         },
     }
     # check both the top level state and the nested state
-    states = schema["content"], schema["content"]["nested_"]["content"]
+    states = (
+        schema["content"]["content"],
+        schema["content"]["content"]["nested_"]["content"],
+    )
     for key, val_expected in expected.items():
         for state in states:
             val_state = state[key]


### PR DESCRIPTION
Those are used by `KNeighbors{Classifier,Regressor}` but were not caught so far because of the default argument.

Unfortunately, we need some special treatment here because the two cython classes, as well as `DistanceMetric`, which is used under the hood, return tuples from `__getstate__` and thus the normal `reduce_get_state` and `reduce_get_instance` methods fail.

LMK if you have a better name than `reduce_based_on_tuple_get_{state,instance}`.

Ready for review @adrinjalali 