### PR TITLE
Add support for partial

### DIFF
--- a/skops/io/_numpy.py
+++ b/skops/io/_numpy.py
@@ -1,5 +1,4 @@
 import io
-from functools import partial
 from pathlib import Path
 from uuid import uuid4
 
@@ -94,8 +93,6 @@ def random_generator_get_instance(state, src):
 # functions we get it from objet's module directly. Therefore sett a especial
 # get_state method for them here. The load is the same as other functions.
 def ufunc_get_state(obj, dst):
-    if isinstance(obj, partial):
-        raise TypeError("partial function are not supported yet")
     res = {
         "__class__": obj.__class__.__name__,  # ufunc
         "__module__": get_module(type(obj)),  # numpy

--- a/skops/io/tests/test_persist.py
+++ b/skops/io/tests/test_persist.py
@@ -1,5 +1,6 @@
 import tempfile
 import warnings
+from functools import partial
 from pathlib import Path
 
 import numpy as np
@@ -114,6 +115,12 @@ def _tested_estimators(type_filter=None):
     yield FunctionTransformer(
         func=special.erf,
         inverse_func=special.erfinv,
+    )
+
+    # partial functions should be supported
+    yield FunctionTransformer(
+        func=partial(np.add, 10),
+        inverse_func=partial(np.add, -10),
     )
 
 


### PR DESCRIPTION
`partial` uses `reduce`/`__getstate__`/`__setstate__` under the hood. To be on the safe side, we hard-code the use of the `partial` class instance of having a dynamically determined class. This should be okay because (AFAIK) there are no partial subclasses in Python. If a user provides a `partial` subclass, they have to provide their own dispatch functions.

Ready for review @adrinjalali 