### PR TITLE
Unit tests check the __dict__ of the estimator

### DIFF
--- a/skops/io/tests/test_persist.py
+++ b/skops/io/tests/test_persist.py
@@ -239,20 +239,6 @@ def assert_params_equal(params1, params2):
             _assert_vals_equal(val1, val2)
 
 
-def _get_learned_attrs(estimator):
-    # Find the learned attributes like "coefs_"
-    attrs = {}
-    for key in estimator.__dict__:
-        if key.startswith("_") or not key.endswith("_"):
-            continue
-
-        val = getattr(estimator, key)
-        if isinstance(val, property):
-            continue
-        attrs[key] = val
-    return attrs
-
-
 @pytest.mark.parametrize(
     "estimator", _tested_estimators(), ids=_get_check_estimator_ids
 )
@@ -331,11 +317,7 @@ def test_can_persist_fitted(estimator):
             estimator.fit(X)
 
     loaded = save_load_round(estimator)
-    # check that params and learned attributes are equal
-    assert_params_equal(estimator.get_params(), loaded.get_params())
-    attrs_est = _get_learned_attrs(estimator)
-    attrs_loaded = _get_learned_attrs(loaded)
-    assert_params_equal(attrs_est, attrs_loaded)
+    assert_params_equal(estimator.__dict__, loaded.__dict__)
 
     for method in [
         "predict",
@@ -452,11 +434,7 @@ if __name__ == "__main__":
             estimator.fit(X)
 
     loaded = save_load_round(estimator)
-    # check that params and learned attributes are equal
-    assert_params_equal(estimator.get_params(), loaded.get_params())
-    attrs_est = _get_learned_attrs(estimator)
-    attrs_loaded = _get_learned_attrs(loaded)
-    assert_params_equal(attrs_est, attrs_loaded)
+    assert_params_equal(estimator.__dict__, loaded.__dict__)
 
     for method in [
         "predict",


### PR DESCRIPTION
Instead of specifically testing `get_params()` and learned parameters (ending on `_`), it's more cautious to check the `__dict__`. This way, certain attributes like `PoissonRegressor._base_loss` are tested, which otherwise would be omitted.

Locally, the same tests pass and fail, so thankfully, none of the missed attributes was buggy.

Please review @adrinjalali 