### PR TITLE
Only allow numpy, scipy, and sklearn functions

### DIFF
--- a/skops/io/_utils.py
+++ b/skops/io/_utils.py
@@ -183,6 +183,9 @@ def _import_obj(module, cls_or_func, package=None):
 
 def gettype(state):
     if "__module__" in state and "__class__" in state:
+        if state["__class__"] == "builtin_function_or_method":
+            builtin_function_or_method = type(len)
+            return builtin_function_or_method
         if state["__class__"] == "function":
             # This special case is due to how functions are serialized. We
             # could try to change it.

--- a/skops/io/exceptions.py
+++ b/skops/io/exceptions.py
@@ -1,7 +1,18 @@
-class UnsupportedTypeException(TypeError):
+class SkopsIoException(Exception):
+    """Base class for skops.io errors"""
+
+
+class UnsupportedTypeException(TypeError, SkopsIoException):
     """Raise when an object of this type is known to be unsupported"""
 
     def __init__(self, obj):
         super().__init__(
             f"Objects of type {obj.__class__.__name__} are not supported yet."
         )
+
+
+class UnsafeTypeError(TypeError, SkopsIoException):
+    """Raise when it's known that this type might be unsafe"""
+
+    def __init__(self, cls_name):
+        super().__init__(f"Objects of type {cls_name} are potentially unsafe")


### PR DESCRIPTION
Notably, this is in order to exclude builtin functions such as `eval`.

At the moment, there is no way to extend the list of safe modules for functions.

I also took the freedom to remove the debugging test code.

Ready for review @adrinjalali 